### PR TITLE
ci: add GitHub Actions workflow to build and attest bailiff

### DIFF
--- a/.github/workflows/bailiff.yml
+++ b/.github/workflows/bailiff.yml
@@ -1,7 +1,10 @@
 name: bailiff
 
 on:
+  pull_request:
   push:
+    tags:
+    - '*'
 
 jobs:
   build:

--- a/.github/workflows/bailiff.yml
+++ b/.github/workflows/bailiff.yml
@@ -1,0 +1,20 @@
+name: bailiff
+
+on:
+  push:
+
+jobs:
+  build:
+    uses: ethereum-optimism/factory/.github/workflows/docker-build.yaml@71910a32b9b897d46f8576a42ade344719d2bba9
+    with:
+      image_name: ${{ github.workflow }}
+      context: .
+      dockerfile: Dockerfile
+      platforms: linux/amd64
+      gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
+      gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,13 +43,6 @@ archives:
       - goos: windows
         format: zip
 
-dockers:
-  - id: main
-    goos: linux
-    goarch: amd64
-    image_templates:
-      - "us-docker.pkg.dev/oplabs-tools-artifacts/images/bailiff:{{ .Tag }}"
-
 changelog:
   sort: asc
   filters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine3.20 as builder
+FROM golang:1.23-alpine3.20 AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
+FROM golang:1.23-alpine3.20 as builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o bailiff ./cmd/bailiff
+
 FROM alpine:3.20.3
 RUN apk add --no-cache ca-certificates git bash openssh
-COPY bailiff /
+COPY --from=builder /app/bailiff /
 ENTRYPOINT ["/bailiff"]


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow to build and attest Docker images of bailiff, replacing CircleCI Docker builds (while keeping goreleaser in CircleCI for binary/archive releases).

Changes:
- Added .github/workflows/bailiff.yml workflow that uses the reusable workflow from ethereum-optimism/factory to build and push Docker images
- Updated Dockerfile to multi-stage build that builds the binary inside Docker, supporting multi-platform builds (linux/amd64, linux/arm64)
- Removed Docker builds from .goreleaser.yml - goreleaser now only builds binaries and archives for releases

Security Benefits:
- SLSA Build Level 3 in-toto provenance attestation attached to images
- Attestations signed with Sigstore (provides same benefit as image signatures)
- Users can verify that images were built from this repository, from a specific branch/tag, and that they were not tampered
- Attestations will appear in the repository attestations page

### provenance verification

We can check that the image comes from this repository and from a certain branch

<img width="971" height="716" alt="Screenshot 2025-11-13 at 13 33 20" src="https://github.com/user-attachments/assets/37a56f04-3976-4ceb-be2c-8867bdea6609" />

### attestations

will be visible at https://github.com/ethereum-optimism/bailiff/attestations

<img width="1392" height="1521" alt="Screenshot 2025-11-13 at 13 34 47" src="https://github.com/user-attachments/assets/2148a74b-238b-47ea-95cb-35f246ede249" />
