### PR TITLE
ci: bump factory workflow to node24-compatible version

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@cc1794a8e99695971560f5354076fbe2ddca9f2e
     with:
       image_name: bailiff
       context: .


### PR DESCRIPTION
Bump factory to pick up Node.js 24 action updates ahead of the June 2, 2026 deprecation deadline.

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/