### PR TITLE
ci: fix factory attest step

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@cc1794a8e99695971560f5354076fbe2ddca9f2e
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@0df70b9f043d552377e641951fe72ca292086e85
     with:
       image_name: bailiff
       context: .


### PR DESCRIPTION
The previous factory SHA (cc1794a8) had a broken attestation step. Bump to the corrected SHA (0df70b9f).